### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main, master ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/drawks/scep2acme/security/code-scanning/1](https://github.com/drawks/scep2acme/security/code-scanning/1)

To address the issue, we will add an explicit `permissions` block to the workflow. This block will be added at the root level of the workflow file, applying to all jobs. Based on the steps in this workflow, the `contents: read` permission is sufficient for most tasks, and `contents: write` may not be needed. However, the `codecov/codecov-action` step might require additional write access (e.g., `actions: write` or `contents: write`) to properly upload coverage reports.

The recommended fix involves:
1. Adding a `permissions` block at the root of the workflow file.
2. Setting `contents: read` for most actions.
3. Adding any required `write` permissions for specific steps, if necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
